### PR TITLE
Refactor `_AnyBounds`.

### DIFF
--- a/Sources/Ranges/AnyRange.swift
+++ b/Sources/Ranges/AnyRange.swift
@@ -97,6 +97,10 @@ extension AnyRange: GeneralizedRange {
   public var bounds: Bounds<Bound>? {
     return self._anyBounds?.bounds(type: Bound.self)
   }
+  
+  public func contains(_ element: Bound) -> Bool {
+    return self._anyBounds?.contains(element) ?? false
+  }
 }
 
 extension AnyRange {

--- a/Sources/Ranges/GeneralizedRange.swift
+++ b/Sources/Ranges/GeneralizedRange.swift
@@ -46,19 +46,22 @@ internal func _validateBounds<Bound>(_ uncheckedBounds: Bounds<Bound>) -> Bool
   return __validateBounds(uncheckedBounds)
 }
 
+internal func _contains<T>(bounds: Bounds<T>?, element: T) -> Bool where T: Comparable {
+  guard let bounds = bounds else { return false }
+  
+  let lowerComparison = bounds.lower._compare(element, side: .lower)
+  let upperComparison = bounds.upper._compare(element, side: .upper)
+  return (
+    (lowerComparison == .orderedSame || lowerComparison == .orderedAscending)
+    &&
+    (upperComparison == .orderedSame || upperComparison == .orderedDescending)
+  )
+}
 
 // Default implementation for functions that are required by `RangeExpression`
 extension GeneralizedRange {
   public func contains(_ element:Bound) -> Bool {
-    guard let bounds = self.bounds else { return false }
-    
-    let lowerComparison = bounds.lower._compare(element, side: .lower)
-    let upperComparison = bounds.upper._compare(element, side: .upper)
-    return (
-      (lowerComparison == .orderedSame || lowerComparison == .orderedAscending)
-      &&
-      (upperComparison == .orderedSame || upperComparison == .orderedDescending)
-    )
+    return _contains(bounds: self.bounds, element: element)
   }
   
   public func relative<C>(to collection: C) -> Range<Bound> where C:Collection, Bound == C.Index {

--- a/Tests/RangesTests/AnyRangeTests.swift
+++ b/Tests/RangesTests/AnyRangeTests.swift
@@ -33,11 +33,17 @@ final class AnyRangeTests: XCTestCase {
     
     let range2: AnyRange<Int> = 0<...<1
     XCTAssertTrue(range2.isEmpty)
+    XCTAssertFalse(range2.contains(0))
     let range2_1: AnyRange<Double> = 0<...<1
     XCTAssertFalse(range2_1.isEmpty)
+    XCTAssertTrue(range2_1.contains(0.5))
     
     let range3: AnyRange<Int> = 1<...
     XCTAssertEqual(range3.relative(to:[0,1,2,3]), 2..<4)
+    
+    let range4: AnyRange<Int> = 100....100
+    XCTAssertTrue(range4.contains(100))
+    XCTAssertFalse(range4.contains(1000))
   }
   
   func test_concatenation() {


### PR DESCRIPTION
* Make a shortcut of `func contains(_:)`.
* Remove unnecessary access controls.